### PR TITLE
Feat -  jetson p11 jp5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 backup/
 test.py
 *.part
+*.whl

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@
 
   ```
 
+- For Jetpack 5 support with Python 3.11 go ahead and run the installation script first to grab a pre-built `onnxruntime-gpu` wheel for `aarch_64` and a few extra dependencies:
+
+  ```bash
+  sh jetson_install.sh 
+
+  pip install .
+
+  ```
+
+
+
 ## Example usage:
 
 - Currently usage closely follows the official package but with a trt swicth (currently being debugged, False is recommended as a result) and expects either an audio file or a numy array:
@@ -93,6 +104,7 @@
   - Release to  start transcription
   - This has been tested on Ubuntu 22.04 and Jetpack 5 on a AGX  Xavier but feel free to open an issue so we can work through any issues!
 
+
   ```bash
   python examples/example_assistant.py
   ```
@@ -112,6 +124,9 @@
 
 
 ### Testing
+
+- Ubuntu 22.04 - RTX 3080, 8-core, Python 3.11 - **passing**
+- AGX Xavier, Jetpack 5.1.3, Python 3.11 - **Passing**
 
  - CI/CD will be expanded as we go - all general instantiation test pass so far.
 

--- a/jetson_install.sh
+++ b/jetson_install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt update
+sudo apt install -y g++-11
+
+sudo apt-get install python3-pip
+sudo apt-get install libopenblas-base libopenmpi-dev libomp-dev portaudio19-dev espeak ffmpeg libespeak1 python3-pyaudio
+
+###grabbing all relevant wheels
+wget https://nvidia.box.com/shared/static/g74cjqh8fcyd9faobm7yeif8mmxdvc0g.whl -O onnxruntime_gpu-1.16.0-cp311-cp311-linux_aarch64.whl
+pip install onnxruntime_gpu-1.16.0-cp311-cp311-linux_aarch64.whl
+
+echo "done!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.26.4
 ffmpeg-python==0.2.0
 transformers==4.41.2
 opencv-python-headless >=4.0.1
-onnxruntime-gpu >=1.16.0
+onnxruntime-gpu >=1.16.0; sys_platform != 'aarch_64'
 onnx==1.13.1
 pillow >=10.1.0
 ftfy >=6.0.3
@@ -10,4 +10,6 @@ tqdm >= 2.2.3
 regex >= 2024.5.15
 cupy==13.2.0
 gdown==5.2.0
+sounddevice==0.4.7
+sshkeyboard==2.3.1
 setuptools-git


### PR DESCRIPTION
- Adding a jetson installation script for Python 3.11 (onnxruntime-gpu)
- Adding a readme update with instructions

**Environment**

- Ubuntu 22.04 - RTX 3080, 8-core
- AGX Xavier - passing

Incoming Changes :
- pytests and ci/cd